### PR TITLE
Close clients that connect too late.

### DIFF
--- a/lib/adm.js
+++ b/lib/adm.js
@@ -1594,8 +1594,15 @@ function createZkClient(connStr, cb) {
     cb = once(cb);
     var zkClient = zk.createClient(connStr);
     zkClient.once('connected', function () {
-        LOG.info('zk connected');
-        return cb(null, zkClient);
+        if (cb.called) {
+            // thanks, but we already gave up
+            LOG.info('zk spurious connected');
+            zkClient.removeAllListeners();
+            zkClient.close();
+        } else {
+            LOG.info('zk connected');
+            return cb(null, zkClient);
+        }
     });
 
     zkClient.once('disconnected', function () {


### PR DESCRIPTION
This survived 2 instances stress testing overnight last night whereas without it it would regularly leak enough connections to ZK to break things very quickly (certainly within hours and IIRC within just a few test reps usually).