### PR TITLE
MANTA-4841 buckets-postgres images should include the pgcrypto extension

### DIFF
--- a/Makefile.postgres
+++ b/Makefile.postgres
@@ -177,5 +177,8 @@ pg12:
 	cd $(DEPSDIR)/postgresql12/contrib/hstore && env \
 		CFLAGS=-m64 LDFLAGS=-m64 \
 		$(MAKE) install DESTDIR="$(RELSTAGEDIR)/root"
+	cd $(DEPSDIR)/postgresql12/contrib/pgcrypto && env \
+		CFLAGS=-m64 LDFLAGS=-m64 \
+		$(MAKE) install DESTDIR="$(RELSTAGEDIR)/root"
 	cd "$(RELSTAGEDIR)/root/$(PG12DIR)/bin"
 	ln -s pg_waldump "$(RELSTAGEDIR)/root/$(PG12DIR)/bin/pg_xlogdump"


### PR DESCRIPTION
We should include the pgcrypto extension in our buckets-postgres images. At very least it provides a way to generated random v4 UUIDs within postgres which could be useful for database migrations. It is likely it could come in handy for other things as well so better just to already have it available.

