### PR TITLE
MANTA-5128 Improve scalability of buckets schema creation

### DIFF
--- a/etc/postgresql.conf
+++ b/etc/postgresql.conf
@@ -529,7 +529,7 @@ default_text_search_config = 'pg_catalog.english'
 #------------------------------------------------------------------------------
 
 #deadlock_timeout = 1s
-#max_locks_per_transaction = 64   # min 10
+max_locks_per_transaction = 1024   # min 10
           # (change requires restart)
 # Note:  Each lock table slot uses ~270 bytes of shared memory, and there are
 # max_locks_per_transaction * (max_connections + max_prepared_transactions)


### PR DESCRIPTION
Bump up max_locks_per_transaction to 1024.

In order to support buckets schemas with large numbers of vnodes. With the default setting of 64, shared memory errors were encountered in testing.