### PR TITLE
Fix postgres12 git reference commit

### DIFF
--- a/tools/mkdevsitters
+++ b/tools/mkdevsitters
@@ -13,7 +13,7 @@ declare -A mds_pgsupported
 mds_pgsupported=(
     ["9.2"]="73c122"
     ["9.6"]="ca9cfe"
-    ["12"]="d1f288"
+    ["12"]="5060275"
 )
 mds_pgbuilddir="/tmp/mds_pgbuild"
 mds_ip="$1"


### PR DESCRIPTION
While testing manatee with postres12 I noticed that the tests setup was somehow broken and tracked it down to upstream changes.
It seems that [the commit used for referencing and building postgres12](https://github.com/postgres/postgres/commit/d1f288) in https://github.com/joyent/manatee/blob/84fac098c7656bb3b735f2fe0663fd09e2706942/tools/mkdevsitters#L16 is no longer available in any upstream branch. 

To fix this, this PR suggests using[ the commit for the release tag](https://github.com/postgres/postgres/commit/5060275) `12.3`.

Fixes #30.